### PR TITLE
IOW-709 change memory because fargate doesnt support 768 mb

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -5,7 +5,7 @@ containerPort: 8080
 artifactoryPath: "wqp"
 gitRepoUrl: "https://github.com/NWQMC/ogcproxy.git"
 gitRepoCredentialsId: "Jenkins-GitHub-Read-Write-Token"
-memory: 768
+memory: 1024
 healthCheck: "/ogcservices/actuator/health"
 deployJobName: "ogcproxy-container-deploy"
 # configuration repository paths


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
move ogcproxy to fargate

Description
-----------
Fargate only accepts discrete units of memory such as 512, 1024.  768 is not accepted so change to 1024

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial